### PR TITLE
Fix unterminated f-string literal

### DIFF
--- a/main.py
+++ b/main.py
@@ -1781,6 +1781,65 @@ async def task_click(query, context: ContextTypes.DEFAULT_TYPE) -> None:
         reputation=user["reputation"] + 1,
         click_reward_last=int(time.time()),
     )
+
+
+# ----------------------------------------------------------------------
+#   Задание: Подписка на канал (проверка подписки)
+# ----------------------------------------------------------------------
+async def task_sub_channel(query, context: ContextTypes.DEFAULT_TYPE) -> None:
+    uid = query.from_user.id
+    user = get_user(uid)
+    # Проверяем подписку
+    try:
+        member = await context.bot.get_chat_member(CHANNEL_ID, uid)
+        is_subscribed = member.status in ("member", "administrator", "creator")
+    except Exception:
+        is_subscribed = False
+
+    if not is_subscribed:
+        # Просим подписаться и вернуться, фикс: корректная f-строка с переносом строки
+        await edit_section(
+            query,
+            caption=f"Подпишитесь на канал и вернитесь:\n{CHANNEL_LINK}",
+            image_key="coins",
+            reply_markup=InlineKeyboardMarkup(
+                [
+                    [InlineKeyboardButton("🔄 Проверить", callback_data="task_sub_channel")],
+                    [InlineKeyboardButton("⬅️ Назад", callback_data="get_coins")],
+                ]
+            ),
+        )
+        return
+
+    # Уже подписан: выдаём награду один раз
+    if user["subscribe_claimed"]:
+        await edit_section(
+            query,
+            caption="✅ Подписка уже подтверждена. Награда была выдана ранее.",
+            image_key="coins",
+            reply_markup=InlineKeyboardMarkup(
+                [[InlineKeyboardButton("⬅️ Назад", callback_data="get_coins")]]
+            ),
+        )
+        return
+
+    reward = 500
+    update_user(
+        uid,
+        coins=min(user["coins"] + reward, MAX_INT),
+        weekly_coins=user["weekly_coins"] + reward,
+        reputation=user["reputation"] + 1,
+        subscribe_claimed=1,
+    )
+    log_user_action(uid, f"Подтвердил подписку на канал, награда {reward}🪙")
+    await edit_section(
+        query,
+        caption=f"🎉 Подписка подтверждена! Вы получили {format_num(reward)}🪙.",
+        image_key="coins",
+        reply_markup=InlineKeyboardMarkup(
+            [[InlineKeyboardButton("⬅️ Назад", callback_data="get_coins")]]
+        ),
+    )
     log_user_action(uid, f"Кликнул и получил {reward}🪙")
     await edit_section(
         query,
@@ -3049,6 +3108,9 @@ async def button(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         return
     if data == "task_referral":
         await task_referral(query, context)
+        return
+    if data == "task_sub_channel":
+        await task_sub_channel(query, context)
         return
     if data == "task_click":
         await task_click(query, context)


### PR DESCRIPTION
Fix `SyntaxError` for an unterminated f-string and add `task_sub_channel` handler.

This resolves the `SyntaxError` by correctly terminating the f-string and implements the "subscribe to channel" task, including subscription verification, one-time reward, and routing for the new handler.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e6c2f17-3e68-4cc4-a990-66ec3765a426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e6c2f17-3e68-4cc4-a990-66ec3765a426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

