### PR TITLE
Fix bot startup errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -2526,7 +2526,7 @@ async def clans_menu(query, context: ContextTypes.DEFAULT_TYPE) -> None:
         # Пользователь уже в клане
         members = get_clan_members(user_clan["id"])
         member_text = "\n".join([
-            f"👤 {['username'] or f'ID{m[\"user_id\"]}'} ({m['role']}) - {m['contribution']} вклада"
+            f"👤 {(m['username'] or f'ID{m['user_id']}')} ({m['role']}) - {m['contribution']} вклада"
             for m in members[:10]  # Показываем только первых 10
         ])
         
@@ -3602,7 +3602,11 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
     # ------------------- Трейд (упрощённый пример) -------------------
     if txt.lower().startswith("/trade"):
-        await start_trade(query, context)   # функция start_trade реализована ниже
+        context.user_data["trade_state"] = {"step": 1}
+        await update.message.reply_photo(
+            MAIN_MENU_IMG,
+            caption="🤝 Трейд: введите ID получателя (user_id).",
+        )
         return
 
     # ------------------- Любой другой текст -------------------


### PR DESCRIPTION
Fix f-string syntax error in clan members list and refactor `/trade` command initiation to prevent bot startup failures and undefined variable errors.

The original f-string for clan members used `['username']` which was a syntax error and prevented the bot from starting. Additionally, the `/trade` command attempted to call `start_trade` with an undefined `query` variable, leading to a `NameError`. The changes correct these issues, ensuring the bot starts and the trade command functions correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9a886f6-0a90-4bf1-847c-19683e52d8e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e9a886f6-0a90-4bf1-847c-19683e52d8e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

