### PR TITLE
Fix unknown argument type for join

### DIFF
--- a/main.py
+++ b/main.py
@@ -2525,10 +2525,11 @@ async def clans_menu(query, context: ContextTypes.DEFAULT_TYPE) -> None:
     if user_clan:
         # Пользователь уже в клане
         members = get_clan_members(user_clan["id"])
-        member_text = "\n".join([
-            f"👤 {['username'] or f'ID{m[\"user_id\"]}'} ({m['role']}) - {m['contribution']} вклада"
-            for m in members[:10]  # Показываем только первых 10
-        ])
+        lines: List[str] = [
+            f"👤 {(m['username'] or f'ID{m['user_id']}')} ({m['role']}) - {m['contribution']} вклада"
+            for m in members[:10]
+        ]
+        member_text = "\n".join(lines)
         
         text = (
             f"⚔️ Ваш клан: {user_clan['name']}\n"


### PR DESCRIPTION
Resolve `join` iterable type error and incorrect username display in clan member list.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b4c2976-99b2-4d27-af5a-4efa0ef62684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b4c2976-99b2-4d27-af5a-4efa0ef62684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

